### PR TITLE
chore: update apiVersion from v1beta1 to v1 in ExternalSecret and ClusterSecretStore configurations

### DIFF
--- a/apps/linkwarden/secret.yaml
+++ b/apps/linkwarden/secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: linkwarden-secret

--- a/apps/openwebui/database-credentials.yaml
+++ b/apps/openwebui/database-credentials.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: openwebui-password-source
@@ -22,7 +22,7 @@ spec:
         key: openwebui
         property: db_password
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: openwebui-db-secret

--- a/apps/postgres/secret.yaml
+++ b/apps/postgres/secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: postgres-superlogin

--- a/infrastructure/cert-manager/secret.yaml
+++ b/infrastructure/cert-manager/secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: cloudflare-secret

--- a/infrastructure/cloudflare-ddns/secret.yaml
+++ b/infrastructure/cloudflare-ddns/secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: cloudflare-ddns-secret

--- a/infrastructure/external-secrets/crs/cluster-secret-store.yaml
+++ b/infrastructure/external-secrets/crs/cluster-secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: vault-global


### PR DESCRIPTION
chore: update apiVersion from v1beta1 to v1 in ExternalSecret and ClusterSecretStore configurations