### PR TITLE
feat(navidrome): enable mtls for wan ingress and cnp to only allow traefik ingress

### DIFF
--- a/apps/navidrome/cnp-traefik-ingress.yaml
+++ b/apps/navidrome/cnp-traefik-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-traefik-ingress
+  namespace: navidrome
+spec:
+  endpointSelector: {}
+
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "4533"
+              protocol: TCP

--- a/apps/navidrome/ingress-wan.yaml
+++ b/apps/navidrome/ingress-wan.yaml
@@ -1,0 +1,18 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: navidrome-wan
+  namespace: navidrome
+spec:
+  entryPoints:
+    - websecure-wan-traffic
+  routes:
+    - match: Host(`navidrome.wevelsiep.com`)
+      kind: Rule
+      services:
+        - name: navidrome
+          port: 80
+  tls:
+    options:
+      name: mtls-required
+      namespace: traefik

--- a/apps/navidrome/kustomization.yaml
+++ b/apps/navidrome/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - cnp-traefik-ingress.yaml
   - configmap.yaml
   - deployment.yaml
   - ingress.yaml
+  - ingress-wan.yaml
   - namespace.yaml
   - service.yaml
   - storage.yaml


### PR DESCRIPTION
feat(navidrome): enable mtls for wan ingress and cnp to only allow traefik ingress